### PR TITLE
switched alarm to use syslog levels

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1627,6 +1627,7 @@ components:
       description: |
         Defines an alarm in terms of its severity and a description of the problem causing it.
         Alarms occupy one bit in the alarm table allowing up to 32 different alarms to be reported.
+        The Syslog severity levels are used.
       type: object
       properties:
         bit_value:
@@ -1634,12 +1635,51 @@ components:
           minimum: 0
           maximum: 31
         severity:
-          type: string
+          type: integer
           enum:
-            - INFO
-            - WARNING
-            - SEVERE
-            - UNKNOWN
+            - 0
+            - 1
+            - 2
+            - 3
+            - 4
+            - 5
+            - 6
+            - 7
+          default: 0
+          examples:
+            - 0
+            - 1
+            - 2
+            - 3
+            - 4
+            - 5
+            - 6
+            - 7
+          oneOf:
+            - const: 0
+              title: Emergency
+              description: System is unusable
+            - const: 1
+              title: Alert
+              description: Immediate action required
+            - const: 2
+              title: Critical
+              description: Critical conditions
+            - const: 3
+              title: Error
+              description: Error conditions
+            - const: 4
+              title: Warning
+              description: Warning conditions
+            - const: 5
+              title: Notice
+              description: Normal but significant condition
+            - const: 6
+              title: Informational
+              description: Informational messages
+            - const: 7
+              title: Debug
+              description: Debug-level messages
         description:
           $ref: '#/components/schemas/polyglot_text'
       required:

--- a/examples/param.alarm_table.yaml
+++ b/examples/param.alarm_table.yaml
@@ -18,28 +18,28 @@ constraint:
   alarm_table:
     alarms:
       - bit_value: 0
-        severity: SEVERE
+        severity: 0
         description:
           display_strings:
             en: Evacuate the studio!
             fr: Evacuer le studio!
             es: Evacuar el estudio!
       - bit_value: 1
-        severity: WARNING
+        severity: 4
         description:
           display_strings:
             en: Don't touch that dial!
             fr: Ne touchez pas à ce bouton!
             es: No toques ese botón!
       - bit_value: 2
-        severity: INFO
+        severity: 6
         description:
           display_strings:
             en: The studio is now safe.
             fr: Le studio est maintenant sûr.
             es: El estudio está ahora seguro.
       - bit_value: 3
-        severity: UNKNOWN
+        severity: 5
         description:
           display_strings:
             en: Something happened but I don't know what.

--- a/interface/schemata/device.json
+++ b/interface/schemata/device.json
@@ -882,7 +882,7 @@
     },
     "alarm": {
       "title": "Alarm",
-      "description": "Defines an alarm in terms of its severity and a description of the problem causing it.\nAlarms occupy one bit in the alarm table allowing up to 32 different alarms to be reported.\n",
+      "description": "Defines an alarm in terms of its severity and a description of the problem causing it.\nAlarms occupy one bit in the alarm table allowing up to 32 different alarms to be reported.\nThe Syslog severity levels are used.\n",
       "type": "object",
       "properties": {
         "bit_value": {
@@ -891,12 +891,69 @@
           "maximum": 31
         },
         "severity": {
-          "type": "string",
+          "type": "integer",
           "enum": [
-            "INFO",
-            "WARNING",
-            "SEVERE",
-            "UNKNOWN"
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "default": 0,
+          "examples": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "oneOf": [
+            {
+              "const": 0,
+              "title": "Emergency",
+              "description": "System is unusable"
+            },
+            {
+              "const": 1,
+              "title": "Alert",
+              "description": "Immediate action required"
+            },
+            {
+              "const": 2,
+              "title": "Critical",
+              "description": "Critical conditions"
+            },
+            {
+              "const": 3,
+              "title": "Error",
+              "description": "Error conditions"
+            },
+            {
+              "const": 4,
+              "title": "Warning",
+              "description": "Warning conditions"
+            },
+            {
+              "const": 5,
+              "title": "Notice",
+              "description": "Normal but significant condition"
+            },
+            {
+              "const": 6,
+              "title": "Informational",
+              "description": "Informational messages"
+            },
+            {
+              "const": 7,
+              "title": "Debug",
+              "description": "Debug-level messages"
+            }
           ]
         },
         "description": {

--- a/interface/schemata/device.yaml
+++ b/interface/schemata/device.yaml
@@ -682,6 +682,7 @@ $defs:
     description: | 
       Defines an alarm in terms of its severity and a description of the problem causing it.
       Alarms occupy one bit in the alarm table allowing up to 32 different alarms to be reported.
+      The Syslog severity levels are used.
     type: object
     properties:
       bit_value:
@@ -689,8 +690,35 @@ $defs:
         minimum: 0
         maximum: 31
       severity:
-        type: string
-        enum: [INFO, WARNING, SEVERE, UNKNOWN]
+        type: integer
+        enum: [0, 1, 2, 3, 4, 5, 6, 7]
+        default: 0
+        examples: [0, 1, 2, 3, 4, 5, 6, 7]
+        oneOf:
+          - const: 0
+            title: Emergency
+            description: "System is unusable"
+          - const: 1
+            title: Alert
+            description: "Immediate action required"
+          - const: 2
+            title: Critical
+            description: "Critical conditions"
+          - const: 3
+            title: Error
+            description: "Error conditions"
+          - const: 4
+            title: Warning
+            description: "Warning conditions"
+          - const: 5
+            title: Notice
+            description: "Normal but significant condition"
+          - const: 6
+            title: Informational
+            description: "Informational messages"
+          - const: 7
+            title: Debug
+            description: "Debug-level messages"
       description:
         $ref: "#/$defs/polyglot_text"
     required: [bit_value, severity, description]


### PR DESCRIPTION
hold off on merging until IBC demo is at code freeze

switches us from using OGP severity levels to Syslog ones.

OGP to Syslog mapping:
INFO => INFORMATIONAL
WARNING => WARNING
SEVERE => ERROR
UNKNOWN => NOTICE
REFUSED => NOTICE