### PR TITLE
restructure schema

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2161,16 +2161,10 @@ components:
       description: Defines STRUCT as a map of string keys to values
       type: object
       properties:
-        struct_value:
-          type: object
-          properties:
-            fields:
-              $ref: '#/components/schemas/struct_fields'
-          required:
-            - fields
-          additionalProperties: false
+        fields:
+          $ref: '#/components/schemas/struct_fields'
       required:
-        - struct_value
+        - fields
       additionalProperties: false
     apply_struct:
       title: STRUCT specialism
@@ -2184,7 +2178,13 @@ components:
         type: object
         properties:
           value:
-            $ref: '#/components/schemas/struct_value'
+            type: object
+            properties:
+              struct_value:
+                $ref: '#/components/schemas/struct_value'
+            required:
+              - struct_value
+            additionalProperties: false
           constraint: false
           precision: false
           max_length: false

--- a/interface/schemata/device.yaml
+++ b/interface/schemata/device.yaml
@@ -967,7 +967,13 @@ $defs:
       type: object
       properties:
         value:
-          $ref: "#/$defs/struct_value"
+          type: object
+          properties:
+            struct_value:
+              $ref: "#/$defs/struct_value"
+          required:
+            - struct_value
+          additionalProperties: false
         
         # structs have no constraints, their children may
         constraint: false
@@ -980,16 +986,10 @@ $defs:
     description: Defines STRUCT as a map of string keys to values
     type: object
     properties:
-      struct_value:
-        type: object
-        properties:
-          fields:
-            $ref: "#/$defs/struct_fields"
-        required:
-          - fields
-        additionalProperties: false
+      fields:
+        $ref: "#/$defs/struct_fields"
     required:
-      - struct_value
+      - fields
     additionalProperties: false
 
   struct_fields:


### PR DESCRIPTION
Closes #23
This PR brings the `struct_array` schema into line with the protos. `$defs/struct_array_values` references `$defs/struct_value`, which used to enforce the `struct_value/fields/<keys>` path as part of a `struct_value`. This forced the `struct_value` property to appear in the `struct_array_values`, which is incorrect. The change is to move the `struct_value` property into the `apply_struct_value` $def so that it only applies to single structs and not struct arrays.

WRONG
```yaml
value:
  struct_array_values:
    struct_values:
      - struct_value: # <-- shouldn't be here
          fields:
            nested_struct:
              struct_value:
                fields:
                  num_1: {int32_value: 1}
                  num_2: {int32_value: 2}
      - struct_value: # <-- shouldn't be here
          fields:
            nested_struct:
              struct_value:
                fields:
                  num_1: {int32_value: 3}
                  num_2: {int32_value: 4}
```
CORRECT
```yaml
value:
  struct_array_values:
    struct_values:
      - fields: # <-- straight to fields
          nested_struct:
            struct_value:
              fields:
                num_1: {int32_value: 1}
                num_2: {int32_value: 2}
      - fields: # <-- straight to fields
          nested_struct:
            struct_value:
              fields:
                num_1: {int32_value: 3}
                num_2: {int32_value: 4}
```