### PR TITLE
add in request-start header

### DIFF
--- a/interface/openapi/openapi.yaml
+++ b/interface/openapi/openapi.yaml
@@ -124,8 +124,9 @@ components:
         The time at which the request was sent,
         <number of milliseconds since start of epoch>
       schema:
-        type: number
-      example: "1234512345123"
+        type: integer
+        minimum: 0
+      example: 1234512345123
 
   responses:
 

--- a/interface/openapi/openapi.yaml
+++ b/interface/openapi/openapi.yaml
@@ -115,6 +115,17 @@ paths:
     $ref: './paths/Access.yaml'
 
 components:
+  parameters:
+    RequestStart:
+      name: Request-Start
+      in: header
+      required: false
+      description: |
+        The time at which the request was sent,
+        <number of milliseconds since start of epoch>
+      schema:
+        type: number
+      example: "1234512345123"
 
   responses:
 

--- a/interface/openapi/paths/Access.yaml
+++ b/interface/openapi/paths/Access.yaml
@@ -35,7 +35,10 @@ get:
 
   tags:
     - Access Management
-    
+
+  parameters:
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   responses:
     "200":
       description: |
@@ -75,6 +78,9 @@ post:
       - st2138:adm:w
   tags:
     - Access Management
+
+  parameters:
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
 
   requestBody:
     required: true

--- a/interface/openapi/paths/Asset.yaml
+++ b/interface/openapi/paths/Asset.yaml
@@ -58,6 +58,8 @@ get:
         enum: [UNCOMPRESSED, GZIP, DEFLATE]
       example: "UNCOMPRESSED"
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   tags:
     - Assets
     
@@ -130,6 +132,8 @@ post:
         $ref: "../../schemata/device.json#/$defs/fqoid"
       example: "image.png"
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   requestBody:
     required: true
     content:
@@ -189,6 +193,8 @@ put:
         $ref: "../../schemata/device.json#/$defs/fqoid"
       example: "image.png"
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   requestBody:
     required: true
     content:
@@ -245,6 +251,8 @@ delete:
       schema:
         $ref: "../../schemata/device.json#/$defs/fqoid"
       example: "image.png"
+
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
   
   requestBody:
     required: true

--- a/interface/openapi/paths/AssetStream.yaml
+++ b/interface/openapi/paths/AssetStream.yaml
@@ -49,6 +49,8 @@ get:
         $ref: "../../schemata/device.json#/$defs/fqoid"
       example: "image.png"
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   tags:
     - Assets
     

--- a/interface/openapi/paths/Command.yaml
+++ b/interface/openapi/paths/Command.yaml
@@ -66,6 +66,8 @@ post:
         enum: ["true"]
         default: "true" # because protobuf defaults to false
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   tags:
     - Commands
     

--- a/interface/openapi/paths/CommandStream.yaml
+++ b/interface/openapi/paths/CommandStream.yaml
@@ -66,6 +66,8 @@ post:
         enum: ["true"]
         default: "true" # because protobuf defaults to false
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   tags:
     - Commands
     

--- a/interface/openapi/paths/Connect.yaml
+++ b/interface/openapi/paths/Connect.yaml
@@ -41,6 +41,8 @@ get:
       schema:
         $ref: "../../schemata/device.json#/$defs/detail_level"
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   tags:
     - Updates  
 

--- a/interface/openapi/paths/Device.yaml
+++ b/interface/openapi/paths/Device.yaml
@@ -51,6 +51,8 @@ get:
       schema:
         $ref: "../../schemata/device.json#/$defs/detail_level"
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   tags:
     - Discovery
 

--- a/interface/openapi/paths/DeviceStream.yaml
+++ b/interface/openapi/paths/DeviceStream.yaml
@@ -49,6 +49,8 @@ get:
       schema:
         $ref: "../../schemata/device.json#/$defs/detail_level"
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   tags:
     - Discovery
 

--- a/interface/openapi/paths/Devices.yaml
+++ b/interface/openapi/paths/Devices.yaml
@@ -38,6 +38,9 @@ get:
   tags:
     - Discovery
 
+  parameters:
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   responses:
     '200':
       description: A list of the slot numbers that are occupied by a device

--- a/interface/openapi/paths/Health.yaml
+++ b/interface/openapi/paths/Health.yaml
@@ -37,6 +37,9 @@ get:
   tags:
     - Discovery
 
+  parameters:
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   responses:
     "200":
       description: Indicates that the Catena REST service is healthy

--- a/interface/openapi/paths/LanguagePack.yaml
+++ b/interface/openapi/paths/LanguagePack.yaml
@@ -51,6 +51,8 @@ get:
         default: "en"
       example: "es"
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   tags:
     - Languages
 
@@ -118,6 +120,8 @@ post:
         type: string
         default: "" 
       example: "fr"
+
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
 
   requestBody:
     required: true
@@ -189,6 +193,8 @@ delete:
         default: "en"
         example: "fr"
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   responses:
     "204":
       description: Empty response - everything is OK
@@ -245,6 +251,8 @@ put:
         type: string
         default: "en"
         example: "fr"
+
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
 
   requestBody:
     required: true

--- a/interface/openapi/paths/Languages.yaml
+++ b/interface/openapi/paths/Languages.yaml
@@ -51,6 +51,8 @@ get:
         $ref: "../../schemata/device.json#/$defs/slot"
       example: 1  
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   tags:
     - Languages
 

--- a/interface/openapi/paths/Param.yaml
+++ b/interface/openapi/paths/Param.yaml
@@ -49,6 +49,8 @@ get:
         $ref: "../../schemata/device.json#/$defs/fqoid"
       example: "text_box"
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   tags:
     - Parameters
 

--- a/interface/openapi/paths/ParamInfo.yaml
+++ b/interface/openapi/paths/ParamInfo.yaml
@@ -51,6 +51,8 @@ get:
       schema:
         $ref: "../../schemata/device.json#/$defs/fqoid"
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   tags:
     - Parameters
     - Subscriptions

--- a/interface/openapi/paths/ParamInfoStream.yaml
+++ b/interface/openapi/paths/ParamInfoStream.yaml
@@ -60,6 +60,8 @@ get:
       schema:
         $ref: "../../schemata/device.json#/$defs/fqoid"
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   tags:
     - Parameters
     - Subscriptions

--- a/interface/openapi/paths/Subscriptions.yaml
+++ b/interface/openapi/paths/Subscriptions.yaml
@@ -42,6 +42,8 @@ get:
       schema:
         $ref: "../../schemata/device.json#/$defs/slot"
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   tags:
     - Subscriptions
     - Parameters
@@ -127,6 +129,8 @@ put:
       description: The slot of the device model containing the subscriptions to update
       schema:
         $ref: "../../schemata/device.json#/$defs/slot"
+
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
   
   tags:
     - Parameters

--- a/interface/openapi/paths/SubscriptionsStream.yaml
+++ b/interface/openapi/paths/SubscriptionsStream.yaml
@@ -42,6 +42,8 @@ get:
       schema:
         $ref: "../../schemata/device.json#/$defs/slot"
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   tags:
     - Subscriptions
     - Parameters

--- a/interface/openapi/paths/TopLevelParamInfoStream.yaml
+++ b/interface/openapi/paths/TopLevelParamInfoStream.yaml
@@ -53,6 +53,8 @@ get:
       style: form
       explode: false
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   tags:
     - Parameters
     - Subscriptions

--- a/interface/openapi/paths/Value.yaml
+++ b/interface/openapi/paths/Value.yaml
@@ -49,6 +49,8 @@ get:
       schema:
         $ref: "../../schemata/device.json#/$defs/fqoid"
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
 
   tags:
     - Parameters
@@ -116,6 +118,7 @@ put:
       schema:
         $ref: "../../schemata/device.json#/$defs/fqoid"
 
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
 
   tags:
     - Parameters

--- a/interface/openapi/paths/Values.yaml
+++ b/interface/openapi/paths/Values.yaml
@@ -50,7 +50,9 @@ put:
       description: The slot of the device model containing the parameters to get info for
       schema:
         $ref: "../../schemata/device.json#/$defs/slot"
-  
+
+    - $ref: '../openapi.yaml#/components/parameters/RequestStart'
+
   tags:
     - Parameters
 


### PR DESCRIPTION
Adds a `Request-Start` header variable to main openapi.yaml. Then imports this header to each path in the spec.

Closes #46 