### PR TITLE
31 float32 inconsistency

### DIFF
--- a/examples/param.float_range.yaml
+++ b/examples/param.float_range.yaml
@@ -11,7 +11,7 @@ value:
   float32_value: 1000.0
 constraint:
   type: FLOAT_RANGE
-  float32_range:
+  float_range:
     min_value: -20.0
     max_value: 20000.0
     display_min: 0.0

--- a/examples/param.simple_struct.yaml
+++ b/examples/param.simple_struct.yaml
@@ -18,7 +18,7 @@ params:
       float32_value: 0.0
     constraint:
       type: FLOAT_RANGE
-      float32_range:
+      float_range:
         min_value: -90.0
         max_value: 90.0
 
@@ -32,7 +32,7 @@ params:
       float32_value: 0.0
     constraint:
       type: FLOAT_RANGE
-      float32_range:
+      float_range:
         min_value: -180.0
         max_value: 180.0
 

--- a/interface/schemata/device.yaml
+++ b/interface/schemata/device.yaml
@@ -821,7 +821,7 @@ $defs:
           properties:
             type:
               const: FLOAT_RANGE
-            float32_range:
+            float_range:
               type: object
               properties:
                 min_value:


### PR DESCRIPTION
renamed `float32_range` to `float_range` so as to be consistent with the protos

Closes #31 