### PR TITLE
Imported Mandatory Params

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -5,7 +5,8 @@
 require_not_root() {
 
   # skip this check if running in a container
-  if [ -f /.dockerenv ]; then
+  if [[ "${IN_CONTAINER_BUILD:-0}" == "1" ]]; then
+    echo "🐳 Container build detected, skipping root check"
     return 0
   fi
 

--- a/examples/device.example.yaml
+++ b/examples/device.example.yaml
@@ -38,6 +38,7 @@ constraints:
 params:
   product:
     type: STRUCT
+    read_only: true
     name:
       display_strings:
         en: Product Information
@@ -54,6 +55,18 @@ params:
         type: STRING
         value:
           string_value: SMPTE
+      serial_number:
+        type: STRING
+        value:
+          string_value: "0000-0000-0000"
+      catena_sdk:
+        type: STRING
+        value:
+          string_value: ""
+      catena_sdk_version:
+        type: STRING
+        value:
+          string_value: ""
     
 # list the access scopes supported by the device.
 # this one supports all scopes.

--- a/examples/device.example.yaml
+++ b/examples/device.example.yaml
@@ -42,31 +42,34 @@ params:
     name:
       display_strings:
         en: Product Information
+    value:
+      struct_value:
+        fields:
+          name:
+            string_value: "Minimal Device"
+          version:
+            string_value: "1.0.0"
+          vendor:
+            string_value: "SMPTE"
+          serial_number:
+            string_value: "0000-0000-0000"
+          catena_sdk:
+            string_value: "example-sdk"
+          catena_sdk_version:
+            string_value: "0.1.0"
     params:
       name:
         type: STRING
-        value: 
-          string_value: Minimal Device
       version:
         type: STRING
-        value:
-          string_value: 1.0.0
       vendor:
         type: STRING
-        value:
-          string_value: SMPTE
       serial_number:
         type: STRING
-        value:
-          string_value: "0000-0000-0000"
       catena_sdk:
         type: STRING
-        value:
-          string_value: ""
       catena_sdk_version:
         type: STRING
-        value:
-          string_value: ""
     
 # list the access scopes supported by the device.
 # this one supports all scopes.
@@ -136,7 +139,7 @@ menu_groups:
           display_strings:
             $key: product
         param_oids:
-          - /product
+          - product
         hidden: false
         disabled: false
         order: 0

--- a/examples/device.example.yaml
+++ b/examples/device.example.yaml
@@ -139,7 +139,7 @@ menu_groups:
           display_strings:
             $key: product
         param_oids:
-          - product
+          - /product
         hidden: false
         disabled: false
         order: 0

--- a/tools/mandatory.js
+++ b/tools/mandatory.js
@@ -83,71 +83,62 @@ function getStringValue(param, productValue, key) {
  * Validates that all mandatory product parameters and scopes are present
  * and have valid values.
  * @param {object} deviceDesc the complete device model object
- * @param {boolean} disableMandatoryEnforcement if true, skip validation
- * @throws {Error} if mandatory parameters are missing or have invalid values
+ * @returns {Array<{message: string, instancePath: string}>} array of errors
+ *   (empty if valid). Each entry carries an instancePath suitable for
+ *   source-map lookup so callers can report line numbers.
  */
-function validateRequiredParamsAndScopes(deviceDesc, disableMandatoryEnforcement = false) {
-    if (disableMandatoryEnforcement) {
-        return;
-    }
+function validateRequiredParamsAndScopes(deviceDesc) {
+    const errors = [];
 
     if (!deviceDesc || !deviceDesc.params || !deviceDesc.params.product) {
-        throw new Error('Missing mandatory product struct in params');
+        errors.push({ message: 'Missing mandatory product struct in params', instancePath: '/params/product' });
+        return errors;
     }
 
-    if (deviceDesc.params.product.type !== 'STRUCT') {
-        throw new Error(`Product parameter must be STRUCT type, not ${deviceDesc.params.product.type}`);
+    const product = deviceDesc.params.product;
+
+    if (product.type !== 'STRUCT') {
+        errors.push({ message: `Product parameter must be STRUCT type, not ${product.type}`, instancePath: '/params/product/type' });
     }
 
-    if (!deviceDesc.params.product.read_only) {
-        throw new Error('Product parameter must be read_only');
+    if (!product.read_only) {
+        errors.push({ message: 'Product parameter must be read_only', instancePath: '/params/product/read_only' });
     }
 
-    const productParams = deviceDesc.params.product.params || {};
-    const productValue = deviceDesc.params.product.value;
-    const productScope = deviceDesc.params.product.access_scope;
+    const productParams = product.params || {};
+    const productValue = product.value;
+    const productScope = product.access_scope;
     const defaultScope = deviceDesc.default_scope;
-
-    const missing = [];
-    const emptyValues = [];
-    const invalidScopes = [];
 
     for (const key of REQUIRED_PARAMS) {
         const param = productParams[key];
+        const basePath = `/params/product/params/${key}`;
 
         if (!param) {
-            missing.push(key);
+            errors.push({ message: `Missing mandatory product parameter '${key}'`, instancePath: basePath });
             continue;
         }
 
         if (param.type !== 'STRING') {
-            missing.push(`${key} (not STRING type)`);
+            errors.push({ message: `Product parameter '${key}' must be STRING type, not ${param.type}`, instancePath: `${basePath}/type` });
             continue;
         }
 
         const derivedScope = getDerivedScope(param, productScope, defaultScope);
         if (derivedScope === "INVALID") {
-            invalidScopes.push(`${key} (derived scope is invalid, must be '${REQUIRED_SCOPE}')`);
+            errors.push({ message: `Product parameter '${key}' has invalid scope (must be '${REQUIRED_SCOPE}')`, instancePath: `${basePath}/access_scope` });
         }
 
         const stringValue = getStringValue(param, productValue, key);
 
         if (stringValue === undefined || stringValue === null) {
-            emptyValues.push(`${key} (no value found)`);
+            errors.push({ message: `Product parameter '${key}' has no value`, instancePath: `${basePath}/value` });
         } else if (String(stringValue).trim() === '') {
-            emptyValues.push(`${key} (empty string value)`);
+            errors.push({ message: `Product parameter '${key}' has empty string value`, instancePath: `${basePath}/value/string_value` });
         }
     }
 
-    const allIssues = [
-        ...missing.map(p => `${p} (missing field)`),
-        ...emptyValues,
-        ...invalidScopes
-    ];
-
-    if (allIssues.length > 0) {
-        throw new Error(`Invalid mandatory product parameters: ${allIssues.join(', ')}`);
-    }
+    return errors;
 }
 
 module.exports = { validateRequiredParamsAndScopes };

--- a/tools/mandatory.js
+++ b/tools/mandatory.js
@@ -1,3 +1,32 @@
+/*
+ * Copyright © MMXXV 2026 by the Society of Motion Picture and Television Engineers
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation and/or
+ *    other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 'use strict';
 
 const REQUIRED_PARAMS = {

--- a/tools/mandatory.js
+++ b/tools/mandatory.js
@@ -1,0 +1,126 @@
+'use strict';
+
+const REQUIRED_PARAMS = {
+    "name": true,
+    "vendor": true,
+    "version": true,
+    "catena_sdk": false,
+    "catena_sdk_version": false,
+    "serial_number": true
+};
+
+const REQUIRED_SCOPE = "st2138:mon";
+
+/**
+ * Derive the effective scope for a parameter by walking up the scope chain.
+ * @param {object} param the sub-parameter descriptor
+ * @param {string|undefined} productScope access_scope on the product param
+ * @param {string|undefined} defaultScope device-level default_scope
+ * @returns {string} "st2138:mon" if valid, "INVALID" otherwise
+ */
+function getDerivedScope(param, productScope, defaultScope) {
+    const scope = param.access_scope || productScope || defaultScope || REQUIRED_SCOPE;
+    return scope === REQUIRED_SCOPE ? scope : "INVALID";
+}
+
+/**
+ * Attempt to read the string value for a product sub-parameter.
+ * Supports two value locations:
+ *   1. Per-sub-param: product.params[key].value.string_value
+ *   2. Struct blob:   product.value.struct_value.fields[key].string_value
+ * @param {object} param the sub-parameter descriptor
+ * @param {object|undefined} productValue the product param's top-level value
+ * @param {string} key the sub-parameter name
+ * @returns {string|undefined}
+ */
+function getStringValue(param, productValue, key) {
+    if (param.value && param.value.string_value !== undefined) {
+        return param.value.string_value;
+    }
+
+    if (productValue &&
+        productValue.struct_value &&
+        productValue.struct_value.fields) {
+        const field = productValue.struct_value.fields[key];
+        if (field && field.string_value !== undefined) {
+            return field.string_value;
+        }
+    }
+
+    return undefined;
+}
+
+/**
+ * Validates that all mandatory product parameters and scopes are present
+ * and have valid values.
+ * @param {object} deviceDesc the complete device model object
+ * @param {boolean} disableMandatoryEnforcement if true, skip validation
+ * @throws {Error} if mandatory parameters are missing or have invalid values
+ */
+function validateRequiredParamsAndScopes(deviceDesc, disableMandatoryEnforcement = false) {
+    if (disableMandatoryEnforcement) {
+        return;
+    }
+
+    if (!deviceDesc || !deviceDesc.params || !deviceDesc.params.product) {
+        throw new Error('Missing mandatory product struct in params');
+    }
+
+    if (deviceDesc.params.product.type !== 'STRUCT') {
+        throw new Error(`Product parameter must be STRUCT type, not ${deviceDesc.params.product.type}`);
+    }
+
+    if (!deviceDesc.params.product.read_only) {
+        throw new Error('Product parameter must be read_only');
+    }
+
+    const productParams = deviceDesc.params.product.params || {};
+    const productValue = deviceDesc.params.product.value;
+    const productScope = deviceDesc.params.product.access_scope;
+    const defaultScope = deviceDesc.default_scope;
+
+    const missing = [];
+    const emptyValues = [];
+    const invalidScopes = [];
+
+    for (const [key, checkValue] of Object.entries(REQUIRED_PARAMS)) {
+        const param = productParams[key];
+
+        if (!param) {
+            missing.push(key);
+            continue;
+        }
+
+        if (param.type !== 'STRING') {
+            missing.push(`${key} (not STRING type)`);
+            continue;
+        }
+
+        const derivedScope = getDerivedScope(param, productScope, defaultScope);
+        if (derivedScope === "INVALID") {
+            invalidScopes.push(`${key} (derived scope is invalid, must be '${REQUIRED_SCOPE}')`);
+        }
+
+        if (checkValue) {
+            const stringValue = getStringValue(param, productValue, key);
+
+            if (stringValue === undefined || stringValue === null) {
+                emptyValues.push(`${key} (no value found)`);
+            } else if (String(stringValue).trim() === '') {
+                emptyValues.push(`${key} (empty string value)`);
+            }
+        }
+    }
+
+    const allIssues = [
+        ...missing.map(p => `${p} (missing field)`),
+        ...emptyValues,
+        ...invalidScopes
+    ];
+
+    if (allIssues.length > 0) {
+        throw new Error(`Invalid mandatory product parameters: ${allIssues.join(', ')}`);
+    }
+}
+
+module.exports = { validateRequiredParamsAndScopes };

--- a/tools/mandatory.js
+++ b/tools/mandatory.js
@@ -29,14 +29,14 @@
 
 'use strict';
 
-const REQUIRED_PARAMS = {
-    "name": true,
-    "vendor": true,
-    "version": true,
-    "catena_sdk": false,
-    "catena_sdk_version": false,
-    "serial_number": true
-};
+const REQUIRED_PARAMS = [
+    "name",
+    "vendor",
+    "version",
+    "catena_sdk",
+    "catena_sdk_version",
+    "serial_number"
+];
 
 const REQUIRED_SCOPE = "st2138:mon";
 
@@ -112,7 +112,7 @@ function validateRequiredParamsAndScopes(deviceDesc, disableMandatoryEnforcement
     const emptyValues = [];
     const invalidScopes = [];
 
-    for (const [key, checkValue] of Object.entries(REQUIRED_PARAMS)) {
+    for (const key of REQUIRED_PARAMS) {
         const param = productParams[key];
 
         if (!param) {
@@ -130,14 +130,12 @@ function validateRequiredParamsAndScopes(deviceDesc, disableMandatoryEnforcement
             invalidScopes.push(`${key} (derived scope is invalid, must be '${REQUIRED_SCOPE}')`);
         }
 
-        if (checkValue) {
-            const stringValue = getStringValue(param, productValue, key);
+        const stringValue = getStringValue(param, productValue, key);
 
-            if (stringValue === undefined || stringValue === null) {
-                emptyValues.push(`${key} (no value found)`);
-            } else if (String(stringValue).trim() === '') {
-                emptyValues.push(`${key} (empty string value)`);
-            }
+        if (stringValue === undefined || stringValue === null) {
+            emptyValues.push(`${key} (no value found)`);
+        } else if (String(stringValue).trim() === '') {
+            emptyValues.push(`${key} (empty string value)`);
         }
     }
 

--- a/tools/validate.js
+++ b/tools/validate.js
@@ -24,7 +24,6 @@
 
 const path = require('node:path');
 const Validator = require('./validator');
-const { validateRequiredParamsAndScopes } = require('./mandatory');
 'use strict'; // <-- now applied after AJV is safely loaded (via validator.js)
 
 const disableMandatory = process.argv.includes('--disable-mandatory-enforcement');
@@ -54,7 +53,9 @@ const schemaName = path.parse(url.pathname).name.split('.')[0];
 const digest = args[3] || null;
 
 (async () => {
-    const validator = new Validator();
+    const validator = new Validator({
+        disableMandatoryParams: disableMandatory
+    });
     console.log(`Applying schema '${schemaName}' to '${url}'`);
     const ans = await validator.validate(schemaName, url, digest);
 
@@ -65,13 +66,8 @@ const digest = args[3] || null;
 
     console.log('✅ Schema validation succeeded.');
 
-    if (schemaName.startsWith('device')) {
-        if (disableMandatory) {
-            console.log('Mandatory parameter enforcement disabled.');
-        } else {
-            validateRequiredParamsAndScopes(ans.data);
-            console.log('✅ Mandatory parameter validation succeeded.');
-        }
+    if (schemaName.startsWith('device') && !disableMandatory) {
+        console.log('✅ Mandatory parameter validation succeeded.');
     }
 
     process.exit(0);

--- a/tools/validate.js
+++ b/tools/validate.js
@@ -66,10 +66,6 @@ const digest = args[3] || null;
 
     console.log('✅ Schema validation succeeded.');
 
-    if (schemaName.startsWith('device') && !disableMandatory) {
-        console.log('✅ Mandatory parameter validation succeeded.');
-    }
-
     process.exit(0);
 })().catch((err) => {
     console.error(`Error: ${err.message}`);

--- a/tools/validate.js
+++ b/tools/validate.js
@@ -24,13 +24,19 @@
 
 const path = require('node:path');
 const Validator = require('./validator');
+const { validateRequiredParamsAndScopes } = require('./mandatory');
 'use strict'; // <-- now applied after AJV is safely loaded (via validator.js)
 
+const disableMandatory = process.argv.includes('--disable-mandatory-enforcement');
+const args = process.argv.filter(a => !a.startsWith('--'));
+
 // get file from command line
-let testfile = process.argv[2];
+let testfile = args[2];
 
 if (!testfile) {
-    console.log('Usage: node validate.js path/to/test/schema-name.object-name.json or .yaml [digest]');
+    console.log('Usage: node validate.js [options] path/to/test/schema-name.object-name.json or .yaml [digest]');
+    console.log('Options:');
+    console.log('  --disable-mandatory-enforcement   Skip mandatory product parameter checks');
     console.log('Example: node validate.js ./tests/device.my-device.json');
     console.log('Example: node validate.js ./tests/device.param.yaml sha256digest');
     process.exit(1);
@@ -45,14 +51,30 @@ const url = new URL(testfile);
 // extract schema name from input filename
 const schemaName = path.parse(url.pathname).name.split('.')[0];
 
-const digest = process.argv[3] || null;
+const digest = args[3] || null;
 
 (async () => {
     const validator = new Validator();
     console.log(`Applying schema '${schemaName}' to '${url}'`);
     const ans = await validator.validate(schemaName, url, digest);
-    console.log(ans.valid ? '✅ Validation succeeded.' : '❌ Validation failed.');
-    process.exit(ans.valid ? 0 : 2);
+
+    if (!ans.valid) {
+        console.log('❌ Validation failed.');
+        process.exit(2);
+    }
+
+    console.log('✅ Schema validation succeeded.');
+
+    if (schemaName.startsWith('device')) {
+        if (disableMandatory) {
+            console.log('Mandatory parameter enforcement disabled.');
+        } else {
+            validateRequiredParamsAndScopes(ans.data);
+            console.log('✅ Mandatory parameter validation succeeded.');
+        }
+    }
+
+    process.exit(0);
 })().catch((err) => {
     console.error(`Error: ${err.message}`);
     process.exit(err.error || 1);

--- a/tools/validator.js
+++ b/tools/validator.js
@@ -6,11 +6,13 @@ const fs = require('fs/promises');
 const path = require('node:path');
 const yaml = require('yaml');
 const schema = require('./data/device.json');
+const { validateRequiredParamsAndScopes } = require('./mandatory');
 
 'use strict'; // <-- now applied after AJV is safely loaded
 
 class Validator {
-    constructor() {
+    constructor(options = {}) {
+        this.disableMandatoryParams = options.disableMandatoryParams || false;
 
         this.ajv = new Ajv({
             strict: true,
@@ -99,6 +101,10 @@ class Validator {
         if (!valid) {
             Validator.showErrors(errors, sourceMap);
             return {valid: false}
+        }
+
+        if (isDeviceSchema && !this.disableMandatoryParams) {
+            validateRequiredParamsAndScopes(data);
         }
 
         return {valid: true, data: data};

--- a/tools/validator.js
+++ b/tools/validator.js
@@ -11,6 +11,11 @@ const { validateRequiredParamsAndScopes } = require('./mandatory');
 'use strict'; // <-- now applied after AJV is safely loaded
 
 class Validator {
+    /**
+     *
+     * @param {object} options optional options
+     * @param {boolean} options.disableMandatoryParams if true, skip mandatory product parameter checks
+     */
     constructor(options = {}) {
         this.disableMandatoryParams = options.disableMandatoryParams || false;
 
@@ -104,7 +109,11 @@ class Validator {
         }
 
         if (isDeviceSchema && !this.disableMandatoryParams) {
-            validateRequiredParamsAndScopes(data);
+            const mandatoryErrors = validateRequiredParamsAndScopes(data);
+            if (mandatoryErrors.length > 0) {
+                Validator.showErrors(mandatoryErrors, sourceMap);
+                return {valid: false};
+            }
         }
 
         return {valid: true, data: data};


### PR DESCRIPTION
## Port mandatory product parameter enforcement from Catena

Adds a post-validation step to the device model validator that ensures every device includes a valid `product` STRUCT with the required sub-parameters: `name`, `vendor`, `version`, `serial_number`, `catena_sdk`, and `catena_sdk_version`. Ported from [Catena's `mandatory.js`](https://github.com/rossvideo/Catena/blob/develop/tools/codegen/mandatory.js), adapted to this repo's CommonJS style and YAML value structure.

### What changed

- **`tools/mandatory.js`** (new) — Validates the `product` param is a read-only STRUCT with all six required STRING sub-params, correct values, and `st2138:mon` scope derivation.
- **`tools/validate.js`** — Runs mandatory checks after AJV succeeds on device schemas. Supports `--disable-mandatory-enforcement` to skip.
- **`examples/device.example.yaml`** — Added `read_only: true` and the three missing sub-params (`serial_number`, `catena_sdk`, `catena_sdk_version`).

### Notable differences from Catena source

- CommonJS (`module.exports`) instead of ESM
- Resolves values from both per-sub-param (`param.value.string_value`) and struct-blob (`product.value.struct_value.fields`) locations
- Wired into the standalone validator CLI rather than a codegen pipeline