### PR TITLE
RequestStart should be int64

### DIFF
--- a/interface/openapi/openapi.yaml
+++ b/interface/openapi/openapi.yaml
@@ -125,6 +125,7 @@ components:
         <number of milliseconds since start of epoch>
       schema:
         type: integer
+        format: int64
         minimum: 0
       example: 1234512345123
 


### PR DESCRIPTION
noticed doing something else that we should make the `RequestStart` header an int64 because openapi integers default to int32