### PR TITLE
add Language-Code header to DeviceRequest

### DIFF
--- a/interface/openapi/paths/Connect.yaml
+++ b/interface/openapi/paths/Connect.yaml
@@ -41,6 +41,13 @@ get:
       schema:
         $ref: "../../schemata/device.json#/$defs/detail_level"
 
+    - name: Language-Code
+      in: header
+      required: false
+      description: Optionally specify the language code for the response.
+      schema:
+        $ref: "../../schemata/device.json#/$defs/language_code"
+
     - $ref: '../openapi.yaml#/components/parameters/RequestStart'
 
   tags:

--- a/interface/openapi/paths/Device.yaml
+++ b/interface/openapi/paths/Device.yaml
@@ -54,7 +54,7 @@ get:
     - name: Language-Code
       in: header
       required: false
-      description: Optionally specify the language for the response.
+      description: Optionally specify the language code for the response.
       schema:
         $ref: "../../schemata/device.json#/$defs/language_code"
 

--- a/interface/openapi/paths/Device.yaml
+++ b/interface/openapi/paths/Device.yaml
@@ -51,6 +51,13 @@ get:
       schema:
         $ref: "../../schemata/device.json#/$defs/detail_level"
 
+    - name: Language-Code
+      in: header
+      required: false
+      description: Optionally specify the language for the response.
+      schema:
+        $ref: "../../schemata/device.json#/$defs/language_code"
+
     - $ref: '../openapi.yaml#/components/parameters/RequestStart'
 
   tags:

--- a/interface/openapi/paths/DeviceStream.yaml
+++ b/interface/openapi/paths/DeviceStream.yaml
@@ -49,6 +49,13 @@ get:
       schema:
         $ref: "../../schemata/device.json#/$defs/detail_level"
 
+    - name: Language-Code
+      in: header
+      required: false
+      description: Optionally specify the language code for the response.
+      schema:
+        $ref: "../../schemata/device.json#/$defs/language_code"
+
     - $ref: '../openapi.yaml#/components/parameters/RequestStart'
 
   tags:


### PR DESCRIPTION
Adding in the `Language-Code` header to better match the grpc DeviceRequest. Chose `Language-Code` instead of `Language` to be consistent with the rest of the openapi spec references to language codes.

Also add header to Connect endpoint, against to match grpc