### PR TITLE
access scope tweaks

### DIFF
--- a/interface/schemata/device.yaml
+++ b/interface/schemata/device.yaml
@@ -117,6 +117,10 @@ properties:
   menu_groups:
     $ref: "#/$defs/menu_groups"
 additionalProperties: false
+required:
+  - slot
+  - access_scopes
+  - default_scope
 
 $defs:
   access_scopes:
@@ -126,6 +130,7 @@ $defs:
     type: array
     items:
       $ref: "#/$defs/access_scope"
+    uniqueItems: true
   
   default_scope:
     title: Default Scope
@@ -133,8 +138,7 @@ $defs:
       The default scope for the device.
       Objects in the model will have this access scope unless overridden
       explicitly, or implicitly by inheritance
-    type: string
-    default: ""
+    $ref: "#/$defs/access_scopes_enum"
 
   slot:
     title: Slot
@@ -1344,14 +1348,22 @@ $defs:
     description: Recommended UI widget to use for the parameter
     type: string
 
+  access_scopes_enum:
+    title: Access Scopes Enum
+    description: |
+      The set of access scopes recognized by ST 2138.
+    type: string
+    enum: [st2138:mon, st2138:op, st2138:cfg, st2138:adm]
+
   access_scope:
     title: Access Scope
     description: |
       The parameter's access scope. If not present, the parameter's parent's
       access scope is used unless the parameter is a top-level one, in which
       case the device's default access scope is used.
-    type: string
-    enum: [st2138:mon, st2138:op, st2138:cfg, st2138:adm]
+    anyOf:
+      - $ref: "#/$defs/access_scopes_enum"
+      - type: string
 
   client_hints:
     title: Client Hints


### PR DESCRIPTION
A few tweaks for how access scopes are validated.

- new `$defs/access_scopes_enum` to share the 4 st2138 access scopes
- `$def/access_scope` changed to `anyOf` `access_scopes_enum` or `string` (needs to be `anyOf` and not `oneOf` because strings in the enum also match string, breaking the ONE part of `oneOf`
- `default_scope` also uses the enum now.
- added `uniqueItems` to `$defs/access_scopes` (the top level list) since there is a comment saying they should be unique, may as well enforce.
- made `slot`, `access_scope` and `default_scope` all required in the device so these changes cannot be avoided by omitting.

Confirmed even with the anyOf the enum still is prompted in an ide:
<img width="708" height="214" alt="image" src="https://github.com/user-attachments/assets/f3cab1b9-00be-48ba-be65-190a62b14735" />
