### PR TITLE
Correct openapi for Command respond flag

### DIFF
--- a/interface/openapi/paths/Command.yaml
+++ b/interface/openapi/paths/Command.yaml
@@ -56,15 +56,15 @@ post:
       description: The fully qualified object ID of the command to execute
       schema:
         $ref: "../../schemata/device.json#/$defs/fqoid"
-    
+
     - name: respond
       in: query
       required: false
-      description: flag to suppress the server's response unless set to true
+      description: flag to suppress the server's response; set to false to opt out, otherwise the server responds
       schema:
         type: string
-        enum: ["true"]
-        default: "true" # because protobuf defaults to false
+        enum: ["false"]
+        default: "true" # because protobuf defaults to false, only specify to opt out
 
     - $ref: '../openapi.yaml#/components/parameters/RequestStart'
 

--- a/interface/openapi/paths/CommandStream.yaml
+++ b/interface/openapi/paths/CommandStream.yaml
@@ -56,15 +56,15 @@ post:
       description: The fully qualified object ID of the command to execute
       schema:
         $ref: "../../schemata/device.json#/$defs/fqoid"
-    
+
     - name: respond
       in: query
       required: false
-      description: flag to suppress the server's response unless set to true
+      description: flag to suppress the server's response; set to false to opt out, otherwise the server responds
       schema:
         type: string
-        enum: ["true"]
-        default: "true" # because protobuf defaults to false
+        enum: ["false"]
+        default: "true" # because protobuf defaults to false, only specify to opt out
 
     - $ref: '../openapi.yaml#/components/parameters/RequestStart'
 


### PR DESCRIPTION
The spec contained the slightly confusing schema for respond:

```yaml
      schema:
        type: string
        enum: ["true"]
        default: "true" # because protobuf defaults to false
```
implying you could only specify `?respond=true` in the url with is also the default. Technically, there's no way that is within spec to set respond = false. So this fixes that.