### PR TITLE
correct openapi for Command respond flag

### DIFF
--- a/interface/openapi/paths/Command.yaml
+++ b/interface/openapi/paths/Command.yaml
@@ -61,12 +61,12 @@ post:
       in: query
       required: false
       description: >-
-        Controls whether the server sends a response body. The server responds
-        unless this is explicitly set to false; any other value (or omitting the
-        parameter) results in a response.
+        Controls whether the server sends a response body. The server does not
+        respond unless this is explicitly set to true; any other value (or
+        omitting the parameter) results in no response.
       schema:
         type: boolean
-        default: true
+        default: false
 
     - $ref: '../openapi.yaml#/components/parameters/RequestStart'
 

--- a/interface/openapi/paths/Command.yaml
+++ b/interface/openapi/paths/Command.yaml
@@ -56,15 +56,14 @@ post:
       description: The fully qualified object ID of the command to execute
       schema:
         $ref: "../../schemata/device.json#/$defs/fqoid"
-    
+
     - name: respond
       in: query
       required: false
-      description: flag to suppress the server's response unless set to true
+      description: flag to suppress the server's response; set to false to opt out, otherwise the server responds
       schema:
-        type: string
-        enum: ["true"]
-        default: "true" # because protobuf defaults to false
+        type: boolean
+        default: true
 
     - $ref: '../openapi.yaml#/components/parameters/RequestStart'
 

--- a/interface/openapi/paths/Command.yaml
+++ b/interface/openapi/paths/Command.yaml
@@ -60,7 +60,10 @@ post:
     - name: respond
       in: query
       required: false
-      description: flag to suppress the server's response; set to false to opt out, otherwise the server responds
+      description: >-
+        Controls whether the server sends a response body. The server responds
+        unless this is explicitly set to false; any other value (or omitting the
+        parameter) results in a response.
       schema:
         type: boolean
         default: true

--- a/interface/openapi/paths/CommandStream.yaml
+++ b/interface/openapi/paths/CommandStream.yaml
@@ -61,12 +61,12 @@ post:
       in: query
       required: false
       description: >-
-        Controls whether the server sends a response body. The server responds
-        unless this is explicitly set to false; any other value (or omitting the
-        parameter) results in a response.
+        Controls whether the server sends a response body. The server does not
+        respond unless this is explicitly set to true; any other value (or
+        omitting the parameter) results in no response.
       schema:
         type: boolean
-        default: true
+        default: false
 
     - $ref: '../openapi.yaml#/components/parameters/RequestStart'
 

--- a/interface/openapi/paths/CommandStream.yaml
+++ b/interface/openapi/paths/CommandStream.yaml
@@ -56,15 +56,14 @@ post:
       description: The fully qualified object ID of the command to execute
       schema:
         $ref: "../../schemata/device.json#/$defs/fqoid"
-    
+
     - name: respond
       in: query
       required: false
-      description: flag to suppress the server's response unless set to true
+      description: flag to suppress the server's response; set to false to opt out, otherwise the server responds
       schema:
-        type: string
-        enum: ["true"]
-        default: "true" # because protobuf defaults to false
+        type: boolean
+        default: true
 
     - $ref: '../openapi.yaml#/components/parameters/RequestStart'
 

--- a/interface/openapi/paths/CommandStream.yaml
+++ b/interface/openapi/paths/CommandStream.yaml
@@ -60,7 +60,10 @@ post:
     - name: respond
       in: query
       required: false
-      description: flag to suppress the server's response; set to false to opt out, otherwise the server responds
+      description: >-
+        Controls whether the server sends a response body. The server responds
+        unless this is explicitly set to false; any other value (or omitting the
+        parameter) results in a response.
       schema:
         type: boolean
         default: true


### PR DESCRIPTION
The spec contained the slightly confusing schema for respond:

```yaml
      schema:
        type: string
        enum: ["true"]
        default: "true" # because protobuf defaults to false
```
I read this as respond defaulting to true, which is not correct I propose just making type boolean and default: false for clarity