### PR TITLE
REST Stream Errors

### DIFF
--- a/interface/openapi/openapi.yaml
+++ b/interface/openapi/openapi.yaml
@@ -115,6 +115,28 @@ paths:
     $ref: './paths/Access.yaml'
 
 components:
+  schemas:
+    # x-sse-event-schema maps SSE event types to their data schemas.
+    # "message" is the default event type when no event: field is sent.
+    SseError:
+      type: object
+      description: >-
+        An error event sent in an SSE stream when an error occurs after
+        HTTP headers have already been sent. Carried as an SSE event with
+        event type "error".
+      required:
+        - code
+      properties:
+        code:
+          type: integer
+          description: The HTTP status code that would have been returned
+        message:
+          type: string
+          description: >-
+            A human-readable error message. Optional because servers may
+            omit or generalize this field in production to avoid exposing
+            internal details.
+
   parameters:
     RequestStart:
       name: Request-Start

--- a/interface/openapi/paths/AssetStream.yaml
+++ b/interface/openapi/paths/AssetStream.yaml
@@ -63,9 +63,9 @@ get:
         text/event-stream:
           schema:
             type: string
-            example: |
-              data: <stringified ExternalObjectPayload>
-              data: <stringified ExternalObjectPayload>
+          example: |
+            data: <stringified ExternalObjectPayload>
+            data: <stringified ExternalObjectPayload>
           x-sse-event-schema:
             message:
               $ref: "../../schemata/device.json#/$defs/external_object_payload"

--- a/interface/openapi/paths/AssetStream.yaml
+++ b/interface/openapi/paths/AssetStream.yaml
@@ -66,7 +66,11 @@ get:
             example: |
               data: <stringified ExternalObjectPayload>
               data: <stringified ExternalObjectPayload>
-      # ExternalObjectPayload doesn't yet have a schema, todo!
+          x-sse-event-schema:
+            message:
+              $ref: "../../schemata/device.json#/$defs/external_object_payload"
+            error:
+              $ref: '../openapi.yaml#/components/schemas/SseError'
           
     "401":
       $ref: '../openapi.yaml#/components/responses/Unauthorized'

--- a/interface/openapi/paths/CommandStream.yaml
+++ b/interface/openapi/paths/CommandStream.yaml
@@ -91,7 +91,6 @@ post:
         content, just the status code.
         The response is a sequence of stringified JSON objects, each containing
         a single command response.
-        Each object in the stream has the following structure:
       content:
         text/event-stream:
           schema:
@@ -101,7 +100,10 @@ post:
             data: <stringified {"response":{"string_value":"Command executed successfully"}}>
             data: <stringified {"exception":{"type":"Invalid Command","error_message":"Error message","details":"Something went wrong"}}>
           x-sse-event-schema:
-            $ref: "../../schemata/device.json#/$defs/command_response"
+            message:
+              $ref: "../../schemata/device.json#/$defs/command_response"
+            error:
+              $ref: '../openapi.yaml#/components/schemas/SseError'
 
     "500":
       $ref: '../openapi.yaml#/components/responses/InternalServerError'

--- a/interface/openapi/paths/Connect.yaml
+++ b/interface/openapi/paths/Connect.yaml
@@ -65,7 +65,7 @@ get:
           schema:
             type: string
           example: |
-            <stringified {"value": {string_value: "Hello, world!"}}>
+            data: <stringified PushUpdates>
           x-sse-event-schema:
             message:
               $ref: "../../schemata/device.json#/$defs/push_updates"

--- a/interface/openapi/paths/Connect.yaml
+++ b/interface/openapi/paths/Connect.yaml
@@ -67,7 +67,10 @@ get:
           example: |
             <stringified {"value": {string_value: "Hello, world!"}}>
           x-sse-event-schema:
-            $ref: "../../schemata/device.json#/$defs/push_updates"
+            message:
+              $ref: "../../schemata/device.json#/$defs/push_updates"
+            error:
+              $ref: '../openapi.yaml#/components/schemas/SseError'
     "400":
       $ref: '../openapi.yaml#/components/responses/BadRequest'
     "401":

--- a/interface/openapi/paths/DeviceStream.yaml
+++ b/interface/openapi/paths/DeviceStream.yaml
@@ -79,7 +79,10 @@ get:
             data: <more DeviceComponents>
           
           x-sse-event-schema:
-            $ref: "../../schemata/device.json#/$defs/device_component"
+            message:
+              $ref: "../../schemata/device.json#/$defs/device_component"
+            error:
+              $ref: '../openapi.yaml#/components/schemas/SseError'
     
     '500':
       $ref: '../openapi.yaml#/components/responses/InternalServerError'

--- a/interface/openapi/paths/ParamInfoStream.yaml
+++ b/interface/openapi/paths/ParamInfoStream.yaml
@@ -83,7 +83,10 @@ get:
             data: <stringified {info: ParamInfo, array_length: 1}>
             data: <stringified {info: ParamInfo, array_length: 2}>
           x-sse-event-schema:
-            $ref: "../../schemata/device.json#/$defs/param_info"
+            message:
+              $ref: "../../schemata/device.json#/$defs/param_info"
+            error:
+              $ref: '../openapi.yaml#/components/schemas/SseError'
 
     "500":
       $ref: '../openapi.yaml#/components/responses/InternalServerError'

--- a/interface/openapi/paths/SubscriptionsStream.yaml
+++ b/interface/openapi/paths/SubscriptionsStream.yaml
@@ -61,7 +61,11 @@ get:
             data: <stringified ComponentParam>
             data: <stringified ComponentParam>
             data: <stringified ComponentParam>
-        
+          x-sse-event-schema:
+            message:
+              $ref: "../../schemata/device.json#/$defs/component_param"
+            error:
+              $ref: '../openapi.yaml#/components/schemas/SseError'
 
     "500":
       $ref: '../openapi.yaml#/components/responses/InternalServerError'

--- a/interface/openapi/paths/TopLevelParamInfoStream.yaml
+++ b/interface/openapi/paths/TopLevelParamInfoStream.yaml
@@ -76,7 +76,10 @@ get:
             data: <stringified {info: ParamInfo, array_length: 1}>
             data: <stringified {info: ParamInfo, array_length: 2}>
           x-sse-event-schema:
-            $ref: "../../schemata/device.json#/$defs/param_info"
+            message:
+              $ref: "../../schemata/device.json#/$defs/param_info"
+            error:
+              $ref: '../openapi.yaml#/components/schemas/SseError'
 
     "500":
       $ref: '../openapi.yaml#/components/responses/InternalServerError'


### PR DESCRIPTION
Building off our existing `x-sse-event-schema` extension, this adds a shared `SseError` schema to openapi.yaml representing a trailer error event. For cases where an HTTP error occurs after headers have already been sent. The error is delivered as an SSE event with `event: error` containing a JSON object with `code` (required) and `message` (optional, may be omitted in production for security).

All stream endpoints (`CommandStream`, `DeviceStream`, `ParamInfoStream`, `TopLevelParamInfoStream`, `AssetStream`, `SubscriptionsStream`, `Connect`) now declare the error event type in their `x-sse-event-schema`. Also added missing `message` schema refs for `AssetStream` (`external_object_payload`) and `SubscriptionsStream` (`component_param`).

Note: All existing endpoints omit the `event: type` line from each event and as such default to the `message` type.

Note: OpenAPI 3.2.0 (published September 2025) introduces native SSE support via `itemSchema` which would let us drop the `x-` extension entirely. However, I'm expecting this is too recent for us to want to rely on it too deeply at this time.

Note: Should also give `-12` a refinement pass to match the new errors.