### PR TITLE
Check Access Scopes

### DIFF
--- a/tools/checks/index.js
+++ b/tools/checks/index.js
@@ -31,6 +31,7 @@
 
 const mandatory = require('./mandatory');
 const nestedValues = require('./nested-values');
+const scopes = require('./scopes');
 const { walkParams } = require('./walker');
 const { WARNING, ERROR } = require('./constants');
 
@@ -54,6 +55,10 @@ function getChecks() {
         {
             name: 'nestedValues',
             createVisitor: nestedValues.createNestedValuesVisitor,
+        },
+        {
+            name: 'scopes',
+            createVisitor: scopes.createScopesVisitor,
         },
     ];
 }

--- a/tools/checks/index.js
+++ b/tools/checks/index.js
@@ -31,14 +31,19 @@
 
 const mandatory = require('./mandatory');
 const nestedValues = require('./nested-values');
+const { walkParams } = require('./walker');
 const { WARNING, ERROR } = require('./constants');
 
 /**
- * Returns the list of all checks. Each check has a `name` and a
- * `run(data, opts)` function that returns an array of errors (empty if the
- * check passes or is disabled/not applicable via opts).
+ * Returns the list of all checks. A check is one of two shapes:
  *
- * @returns {Array<{name: string, run: function(object, object): Array}>}
+ * - a standalone check `{ name, run(data, opts) }` that returns an array of
+ *   errors (empty if the check passes or is disabled/not applicable via opts);
+ * - a walk check `{ name, createVisitor(data, opts) }` that returns a walker
+ *   visitor (or null to opt out). Walk checks share a single traversal of the
+ *   parameter hierarchy, appending their findings to a shared list.
+ *
+ * @returns {Array<{name: string, run?: function(object, object): Array, createVisitor?: function(object, object): (object|null)}>}
  */
 function getChecks() {
     return [
@@ -48,13 +53,16 @@ function getChecks() {
         },
         {
             name: 'nestedValues',
-            run: nestedValues.checkNestedValues,
+            createVisitor: nestedValues.createNestedValuesVisitor,
         },
     ];
 }
 
 /**
- * Runs all applicable checks against the provided data.
+ * Runs all applicable checks against the provided data. Standalone checks are
+ * run directly; walk checks contribute a visitor to a single shared traversal
+ * of the parameter tree so it is only walked once regardless of how many walk
+ * checks are registered.
  *
  * @param {object} data the parsed descriptor to validate
  * @param {object} opts
@@ -64,11 +72,20 @@ function getChecks() {
  */
 function runChecks(data, opts) {
     const errors = [];
+    const visitors = [];
+
     const checks = module.exports.getChecks();
     for (const check of checks) {
-        const checkErrors = check.run(data, opts);
-        errors.push(...checkErrors);
+        if (typeof check.run === 'function') {
+            errors.push(...check.run(data, opts));
+        } else if (typeof check.createVisitor === 'function') {
+            const visitor = check.createVisitor(data, opts);
+            if (visitor) visitors.push(visitor);
+        }
     }
+
+    walkParams(data, visitors, errors);
+
     return errors;
 }
 

--- a/tools/checks/nested-values.js
+++ b/tools/checks/nested-values.js
@@ -32,102 +32,104 @@
 const { WARNING } = require('./constants');
 
 /**
- * 
- * @param {object} desc The input object to check
+ * Create a walker visitor that flags nested parameter values not referenced by
+ * any template_oid, and top-level parameters that lack a value while not being
+ * templates. The visitor gathers every template_oid as it walks the tree and
+ * defers the nested-value decision to `finalize`, since a referencing
+ * template_oid may appear anywhere in the hierarchy.
+ *
+ * Rules (each produces a WARNING):
+ *
+ *   R1. Top-level param (depth 0) with NO value AND NO template_oid
+ *       -> "Top-level parameter '<key>' has no value and is not a template".
+ *       Top-level params are expected to carry a value. A template
+ *       (template_oid present) is exempt from R1; it may or may not also declare
+ *       its own value, and either is allowed.
+ *
+ *   R2. Nested param (depth >= 1) WITH a value that is NOT referenced by any
+ *       template_oid anywhere in the tree
+ *       -> "Nested value found in parameter '<key>' which is not referenced by
+ *       any template_oid". Sub-params should not carry standalone values unless
+ *       some param points at them via template_oid.
+ *
+ * Non-rules (explicitly NOT flagged):
+ *   - Top-level param WITH a value (expected, never flagged).
+ *   - Top-level param that is a template (has template_oid): exempt from R1,
+ *     whether or not it also declares its own value.
+ *   - Nested param with NO value (nothing to reference, never flagged).
+ *   - Nested param whose path IS referenced by a template_oid: exempt from R2.
+ *
+ * @param {object} desc The device descriptor to check
  * @param {object} opts Collection of options
  * @param {string} opts.schemaName The schema name of the input object
  * @param {boolean} opts.disableNestedValueChecks If true, skip checks for nested values
- * @returns {Array<{message: string, instancePath: string, type: string}>} Array of error messages for any nested values found
+ * @returns {import('./walker').Visitor|null} a visitor, or null if the check does not apply
  */
-function checkNestedValues(desc, opts) {
+function createNestedValuesVisitor(desc, opts) {
     // base disable checks
-    if (opts.disableNestedValueChecks) return [];
-    if (opts.schemaName !== 'device') return [];
+    if (opts.disableNestedValueChecks) return null;
+    if (opts.schemaName !== 'device') return null;
 
-    // no device, nothing to do
-    if (!desc) return [];
+    // no device or no params, nothing to check
+    if (!desc || !desc.params) return null;
 
-    // if the device has no params, there's nothing to check
-    if (!desc.params) return [];
-
-    // first scan for all template_oids and build a map of them
     const templateOids = new Set();
-    for (const param of Object.values(desc.params)) {
-        searchTemplate(param, templateOids);
-    }
+    const candidates = [];
 
-    const warnings = [];
-    // go through each top-level param
-    for (const [key, param] of Object.entries(desc.params)) {
-        // check if it has a value, it should unless its a template
-        if ((param.value === undefined || param.value === null) && !param.template_oid) {
-            warnings.push({
-                message: `Top-level parameter '${key}' has no value and is not a template`,
-                // leading slash, this is a json pointer for the source map, not an fqoid
-                instancePath: `/params/${key}/value`,
-                type: WARNING,
-            });
-        }
+    return {
+        visit(ctx, warnings) {
+            const { param, key, path, depth } = ctx;
 
-        // look for any nested values in the params
-        checkParam(param, `/params/${key}`, templateOids, warnings);
-    }
+            const isTopLevel = depth === 0;
+            const isTemplate = Boolean(param.template_oid);
+            const hasValue = param.value !== undefined && param.value !== null;
 
-    return warnings;
+            // every template_oid is recorded up front so R2 can be resolved in
+            // finalize, once the full set of references is known
+            if (isTemplate) {
+                templateOids.add(param.template_oid);
+            }
+
+            // R1: top-level param with no value and not a template -> WARNING
+            if (isTopLevel) {
+                if (!hasValue && !isTemplate) {
+                    warnings.push({
+                        message: `Top-level parameter '${key}' has no value and is not a template`,
+                        // leading slash, this is a json pointer for the source map, not an fqoid
+                        instancePath: `${path}/value`,
+                        type: WARNING,
+                    });
+                }
+                // top-level params are never subject to R2, so stop here
+                return;
+            }
+
+            // R2 candidate: a nested param that carries a value. The template_oid
+            // that would justify it may not have been seen yet, so defer the
+            // decision to finalize. Nested params without a value are never flagged.
+            if (hasValue) {
+                candidates.push({ key, path });
+            }
+        },
+        finalize(warnings) {
+            // R2: for each nested value, flag it unless some template_oid points
+            // at its path
+            for (const { key, path } of candidates) {
+                // convert from source map pointer to template_oid by replacing /params/ with /
+                // and removing the leading slash
+                const template_oid = path.replaceAll('/params/', '/').substring(1);
+
+                const isReferenced = templateOids.has(template_oid);
+                if (!isReferenced) {
+                    warnings.push({
+                        message: `Nested value found in parameter '${key}' which is not referenced by any template_oid`,
+                        instancePath: `${path}/value`,
+                        type: WARNING,
+                    });
+                }
+            }
+        },
+    };
 }
 
-/**
- * Search for template_oid in the given object and add them to the templateOids set.
- * @param {object} obj The object to search
- * @param {Set<string>} templateOids The set to add found template_oids to
- * @returns {void}
- */
-function searchTemplate(obj, templateOids) {
-    if (obj.template_oid) {
-        templateOids.add(obj.template_oid);
-    }
-    if (obj.params) {
-        for (const param of Object.values(obj.params)) {
-            searchTemplate(param, templateOids);
-        }
-    }
-}
-
-/**
- * Check the given parameter for nested values and warn if its not a template_oid.
- * @param {object} param The parameter to check
- * @param {string} path The current path in the object
- * @param {Set<string>} templateOids The set of template_oids to check against
- * @param {Array<{message: string, instancePath: string, type: string}>} warnings The array to add warnings to
- * @returns {void}
- */
-function checkParam(param, path, templateOids, warnings) {
-    // nothing to check if there are no sub-params
-    if (!param.params) return;
-
-    for (const [key, subParam] of Object.entries(param.params)) {
-        const subPath = `${path}/params/${key}`;
-
-        // recursively check sub-params
-        checkParam(subParam, subPath, templateOids, warnings);
-
-        // no value, no problem
-        if (subParam.value === undefined || subParam.value === null) {
-            continue;
-        }
-
-        // if the param has a value, check if something else references it as a template_oid
-        // convert from source map pointer to template_oid by replacing /params/ with /
-        // and removing the leading slash
-        const template_oid = subPath.replaceAll('/params/', '/').substring(1);
-        if (!templateOids.has(template_oid)) {
-            warnings.push({
-                message: `Nested value found in parameter '${key}' which is not referenced by any template_oid`,
-                instancePath: `${subPath}/value`,
-                type: WARNING
-            });
-        }
-    }
-}
-
-module.exports = { checkNestedValues };
+module.exports = { createNestedValuesVisitor };

--- a/tools/checks/scopes.js
+++ b/tools/checks/scopes.js
@@ -1,0 +1,125 @@
+/*
+ * Copyright © MMXXVI 2026 by the Society of Motion Picture and Television Engineers
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation and/or
+ *    other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+const { ERROR } = require('./constants');
+
+/**
+ * Create a walker visitor that flags any parameter whose `access_scope` is not
+ * one of the access scopes declared at the device level (`access_scopes`).
+ *
+ * Rules (each produces an ERROR):
+ *
+ *   R1. Any param (at any depth) whose explicit `access_scope` is NOT one of the
+ *       device's declared `access_scopes`
+ *       -> "Parameter '<key>' has access_scope '<scope>' which is not declared
+ *       in the device's access_scopes". Every scope a param uses must be listed
+ *       at the device level.
+ *
+ *   R2. Any TOP-LEVEL command whose explicit `access_scope` is NOT one of the
+ *       device's declared `access_scopes`
+ *       -> "Command '<key>' has access_scope '<scope>' which is not declared in
+ *       the device's access_scopes". Commands are a top-level map that shares
+ *       the param schema, so they also carry an `access_scope` that must be
+ *       declared at the device level. This is checked in `finalize`, since the
+ *       walker only traverses params, not commands.
+ *
+ * Non-rules (explicitly NOT flagged):
+ *   - Param with NO explicit access_scope: it inherits from its parent or the
+ *     device default, so there is nothing to check here.
+ *   - Param whose access_scope IS in the declared set: exempt from R1.
+ *   - A command's nested "params" (its arguments): although they share the param
+ *     schema and may carry an access_scope, that scope has no meaning for an
+ *     argument, so it is ignored. Only top-level commands are checked (R2).
+ *   - Command whose access_scope IS in the declared set: exempt from R2.
+ *
+ * @param {object} desc The device descriptor to check
+ * @param {object} opts Collection of options
+ * @param {string} opts.schemaName The schema name of the input object
+ * @param {boolean} opts.disableScopeChecks If true, skip checks for invalid scopes
+ * @returns {import('./walker').Visitor|null} a visitor, or null if the check does not apply
+ */
+function createScopesVisitor(desc, opts = {}) {
+    // base disable checks
+    if (opts.disableScopeChecks) return null;
+    if (opts.schemaName !== 'device') return null;
+
+    // no device, nothing to do
+    if (!desc) return null;
+
+    const scopes = new Set();
+    for (const scope of desc.access_scopes || []) {
+        // rely on schema validation to ensure that the scope is a string
+        scopes.add(scope);
+    }
+
+    return {
+        visit(ctx, warnings) {
+            const scope = ctx.param.access_scope;
+
+            // a param without an explicit access_scope inherits from its
+            // parent or the device default, so there is nothing to check here
+            if (scope === undefined || scope === null) return;
+
+            // R1: explicit access_scope not declared at the device level -> ERROR
+            const isDeclared = scopes.has(scope);
+            if (!isDeclared) {
+                warnings.push({
+                    message: `Parameter '${ctx.key}' has access_scope '${scope}' which is not declared in the device's access_scopes`,
+                    instancePath: `${ctx.path}/access_scope`,
+                    type: ERROR,
+                });
+            }
+        },
+        finalize(warnings) {
+            // R2: top-level commands share the param schema and carry an
+            // access_scope of their own. The walker only visits params, so
+            // commands are checked here. Command arguments (nested params) are
+            // intentionally NOT checked, as their access_scope is meaningless.
+            for (const [key, command] of Object.entries(desc.commands || {})) {
+                const scope = command.access_scope;
+
+                // no explicit access_scope on the command, nothing to check
+                if (scope === undefined || scope === null) continue;
+
+                const isDeclared = scopes.has(scope);
+                if (!isDeclared) {
+                    warnings.push({
+                        message: `Command '${key}' has access_scope '${scope}' which is not declared in the device's access_scopes`,
+                        instancePath: `/commands/${key}/access_scope`,
+                        type: ERROR,
+                    });
+                }
+            }
+        },
+    };
+}
+
+module.exports = { createScopesVisitor };

--- a/tools/checks/walker.js
+++ b/tools/checks/walker.js
@@ -1,0 +1,116 @@
+/*
+ * Copyright © MMXXVI 2026 by the Society of Motion Picture and Television Engineers
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation and/or
+ *    other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+/**
+ * @typedef {object} WalkContext
+ * @property {object} param the parameter descriptor currently being visited
+ * @property {string} key the parameter's key within its parent's param map
+ * @property {string} path JSON pointer to the parameter (e.g. `/params/product/params/name`)
+ * @property {object|null} parent the parent parameter descriptor, or null for top-level params
+ * @property {Array<{key: string, param: object}>} ancestors ancestor params from root to parent
+ * @property {number} depth 0 for top-level params, incremented for each nesting level
+ * @property {object} desc the root device descriptor being walked
+ */
+
+/**
+ * @typedef {object} Visitor
+ * @property {function(WalkContext, Array): void} visit called once per parameter
+ * @property {function(Array): void} [finalize] called once after the walk completes,
+ *   for checks whose per-parameter decisions depend on state gathered across the whole tree
+ */
+
+/**
+ * Walk every parameter in a device descriptor depth-first (pre-order), invoking
+ * each visitor once per parameter with a shared context. This lets multiple
+ * checks share a single traversal of the parameter hierarchy: each visitor
+ * appends its findings to the shared `warnings` list.
+ *
+ * After every parameter has been visited, each visitor's optional `finalize`
+ * hook is called so checks that need the full tree state (for example, a set of
+ * template references gathered along the way) can emit their deferred findings.
+ *
+ * @param {object} desc the root device descriptor (with a `params` map)
+ * @param {Array<Visitor>} visitors the visitors to invoke for each parameter
+ * @param {Array<{message: string, instancePath: string, type?: string}>} warnings
+ *   the shared list that visitors append their findings to
+ * @returns {void}
+ */
+function walkParams(desc, visitors, warnings) {
+    if (!desc || !desc.params || visitors.length === 0) return;
+
+    for (const [key, param] of Object.entries(desc.params)) {
+        walkParam(param, {
+            param,
+            key,
+            path: `/params/${key}`,
+            parent: null,
+            ancestors: [],
+            depth: 0,
+            desc,
+        }, visitors, warnings);
+    }
+
+    for (const visitor of visitors) {
+        visitor.finalize?.(warnings);
+    }
+}
+
+/**
+ * Recursively visit a single parameter and its sub-parameters.
+ * @param {object} param the parameter descriptor to visit
+ * @param {WalkContext} ctx the context describing where `param` sits in the tree
+ * @param {Array<Visitor>} visitors the visitors to invoke
+ * @param {Array} warnings the shared findings list
+ * @returns {void}
+ */
+function walkParam(param, ctx, visitors, warnings) {
+    for (const visitor of visitors) {
+        visitor.visit(ctx, warnings);
+    }
+
+    if (!param.params) return;
+
+    const childAncestors = [...ctx.ancestors, { key: ctx.key, param }];
+    for (const [key, child] of Object.entries(param.params)) {
+        walkParam(child, {
+            param: child,
+            key,
+            path: `${ctx.path}/params/${key}`,
+            parent: param,
+            ancestors: childAncestors,
+            depth: ctx.depth + 1,
+            desc: ctx.desc,
+        }, visitors, warnings);
+    }
+}
+
+module.exports = { walkParams };
+

--- a/tools/checks/walker.js
+++ b/tools/checks/walker.js
@@ -56,6 +56,8 @@
  * After every parameter has been visited, each visitor's optional `finalize`
  * hook is called so checks that need the full tree state (for example, a set of
  * template references gathered along the way) can emit their deferred findings.
+ * `finalize` always runs (given a descriptor and at least one visitor), even
+ * when the descriptor has no params, so params-less checks are not skipped.
  *
  * @param {object} desc the root device descriptor (with a `params` map)
  * @param {Array<Visitor>} visitors the visitors to invoke for each parameter
@@ -64,9 +66,9 @@
  * @returns {void}
  */
 function walkParams(desc, visitors, warnings) {
-    if (!desc || !desc.params || visitors.length === 0) return;
+    if (!desc || visitors.length === 0) return;
 
-    for (const [key, param] of Object.entries(desc.params)) {
+    for (const [key, param] of Object.entries(desc.params || {})) {
         walkParam(param, {
             param,
             key,

--- a/tools/tests/checks/index.test.js
+++ b/tools/tests/checks/index.test.js
@@ -35,11 +35,11 @@ describe('getChecks', () => {
     // lock in the expected checks
     test('returns all checks', () => {
         const result = checks.getChecks();
-        expect(result).toHaveLength(2);
+        expect(result).toHaveLength(3);
         expect(result[0].name).toBe('mandatory');
         expect(result[0].run).toBe(mandatory.validateRequiredParamsAndScopes);
         expect(result[1].name).toBe('nestedValues');
-        expect(result[1].run).toBe(nestedValues.checkNestedValues);
+        expect(result[1].createVisitor).toBe(nestedValues.createNestedValuesVisitor);
     });
 });
 
@@ -103,5 +103,83 @@ describe('runChecks', () => {
 
         checks.runChecks({}, { schemaName: 'param' });
         expect(getChecksSpy).toHaveBeenCalledWith();
+    });
+
+    // walk checks contribute a visitor that shares a single traversal
+    test('creates visitors for walk checks and walks the param tree once', () => {
+        const opts = { schemaName: 'device' };
+        const testData = { params: { foo: {}, bar: {} } };
+
+        const visit = jest.fn((ctx, warnings) => {
+            warnings.push({ message: `visited ${ctx.key}`, instancePath: ctx.path });
+        });
+        const createVisitor = jest.fn(() => ({ visit }));
+
+        getChecksSpy.mockReturnValue([
+            { name: 'walkCheck', createVisitor },
+        ]);
+
+        const result = checks.runChecks(testData, opts);
+
+        // createVisitor is called once with data and opts
+        expect(createVisitor).toHaveBeenCalledTimes(1);
+        expect(createVisitor).toHaveBeenCalledWith(testData, opts);
+        // the visitor is invoked once per param in a single traversal
+        expect(visit).toHaveBeenCalledTimes(2);
+        expect(result).toEqual([
+            { message: 'visited foo', instancePath: '/params/foo' },
+            { message: 'visited bar', instancePath: '/params/bar' },
+        ]);
+    });
+
+    // walk checks that opt out (return null) are skipped
+    test('skips walk checks whose createVisitor returns null', () => {
+        const opts = { schemaName: 'param' };
+        const testData = { params: { foo: {} } };
+
+        const createVisitor = jest.fn(() => null);
+
+        getChecksSpy.mockReturnValue([
+            { name: 'walkCheck', createVisitor },
+        ]);
+
+        const result = checks.runChecks(testData, opts);
+
+        expect(createVisitor).toHaveBeenCalledWith(testData, opts);
+        expect(result).toEqual([]);
+    });
+
+    // checks that expose neither a run function nor a createVisitor are ignored
+    test('ignores checks with neither run nor createVisitor', () => {
+        const testData = { params: { foo: {} } };
+
+        getChecksSpy.mockReturnValue([
+            { name: 'inert' },
+        ]);
+
+        const result = checks.runChecks(testData, { schemaName: 'device' });
+        expect(result).toEqual([]);
+    });
+
+    // standalone and walk checks combine their findings
+    test('combines errors from standalone run checks and walk visitors', () => {
+        const testData = { params: { foo: {} } };
+        const runError = { message: 'run failed', instancePath: '/run' };
+
+        getChecksSpy.mockReturnValue([
+            { name: 'standalone', run: () => [runError] },
+            {
+                name: 'walkCheck',
+                createVisitor: () => ({
+                    visit: (ctx, warnings) => warnings.push({ message: 'walk finding', instancePath: ctx.path }),
+                }),
+            },
+        ]);
+
+        const result = checks.runChecks(testData, { schemaName: 'device' });
+        expect(result).toEqual([
+            runError,
+            { message: 'walk finding', instancePath: '/params/foo' },
+        ]);
     });
 });

--- a/tools/tests/checks/index.test.js
+++ b/tools/tests/checks/index.test.js
@@ -30,6 +30,7 @@
 const checks = require('../../checks/index');
 const mandatory = require('../../checks/mandatory');
 const nestedValues = require('../../checks/nested-values');
+const scopes = require('../../checks/scopes');
 
 describe('getChecks', () => {
     // lock in the expected checks
@@ -40,6 +41,8 @@ describe('getChecks', () => {
         expect(result[0].run).toBe(mandatory.validateRequiredParamsAndScopes);
         expect(result[1].name).toBe('nestedValues');
         expect(result[1].createVisitor).toBe(nestedValues.createNestedValuesVisitor);
+        expect(result[2].name).toBe('scopes');
+        expect(result[2].createVisitor).toBe(scopes.createScopesVisitor);
     });
 });
 

--- a/tools/tests/checks/nested-values.test.js
+++ b/tools/tests/checks/nested-values.test.js
@@ -27,8 +27,18 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-const { checkNestedValues } = require('../../checks/nested-values');
+const { createNestedValuesVisitor } = require('../../checks/nested-values');
+const { walkParams } = require('../../checks/walker');
 const { WARNING } = require('../../checks/constants');
+
+// drive the nested-values visitor through the walker the same way runChecks does
+function checkNestedValues(desc, opts) {
+    const visitor = createNestedValuesVisitor(desc, opts);
+    if (!visitor) return [];
+    const warnings = [];
+    walkParams(desc, [visitor], warnings);
+    return warnings;
+}
 
 describe('checkNestedValues', () => {
 

--- a/tools/tests/checks/scopes.test.js
+++ b/tools/tests/checks/scopes.test.js
@@ -1,0 +1,278 @@
+/*
+ * Copyright © MMXXVI 2026 by the Society of Motion Picture and Television Engineers
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation and/or
+ *    other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+const { createScopesVisitor } = require('../../checks/scopes');
+const { walkParams } = require('../../checks/walker');
+const { ERROR } = require('../../checks/constants');
+
+// drive the scopes visitor through the walker the same way runChecks does
+function checkScopes(desc, opts) {
+    const visitor = createScopesVisitor(desc, opts);
+    if (!visitor) return [];
+    const warnings = [];
+    walkParams(desc, [visitor], warnings);
+    return warnings;
+}
+
+describe('checkScopes', () => {
+
+    // A valid device that declares a set of access scopes and only uses
+    // scopes drawn from that set across its parameter hierarchy.
+    const VALID_DEVICE = {
+        access_scopes: ['st2138:mon', 'st2138:op', 'st2138:cfg'],
+        default_scope: 'st2138:mon',
+        params: {
+            parent: {
+                type: 'STRUCT',
+                access_scope: 'st2138:op',
+                params: {
+                    child: {
+                        type: 'STRING',
+                        access_scope: 'st2138:cfg',
+                    },
+                    sibling: {
+                        type: 'INT32',
+                        // no access_scope, inherits from parent
+                    },
+                },
+            },
+            deep_parent: {
+                type: 'STRUCT',
+                params: {
+                    mid: {
+                        type: 'STRUCT',
+                        params: {
+                            leaf: {
+                                type: 'INT32',
+                                access_scope: 'st2138:mon',
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        commands: {
+            do_thing: {
+                type: 'STRUCT',
+                access_scope: 'st2138:op',
+                params: {
+                    // command arguments share the param schema and may carry an
+                    // access_scope, but it is ignored for arguments
+                    arg: {
+                        type: 'STRING',
+                        access_scope: 'st2138:bogus',
+                    },
+                },
+            },
+            other_thing: {
+                type: 'STRUCT',
+                // no access_scope, nothing to check
+            },
+        },
+    };
+
+    const ENABLED_OPTS = { schemaName: 'device', disableScopeChecks: false };
+
+    let device;
+    beforeEach(() => {
+        device = structuredClone(VALID_DEVICE);
+    });
+
+    // baseline test, does a well-formed device pass with no errors?
+    test('returns no errors for a valid device', () => {
+        const result = checkScopes(device, ENABLED_OPTS);
+        expect(result).toEqual([]);
+    });
+
+    // test for no device, should return empty
+    test('returns empty when no device is provided', () => {
+        const result = checkScopes(null, ENABLED_OPTS);
+        expect(result).toEqual([]);
+    });
+
+    // test that disabling the check works
+    test('returns empty when disabled', () => {
+        device.params.parent.access_scope = 'st2138:bogus';
+        const result = checkScopes(device, { schemaName: 'device', disableScopeChecks: true });
+        expect(result).toEqual([]);
+        // prove that it would have warned if the check was enabled
+        const result2 = checkScopes(device, ENABLED_OPTS);
+        expect(result2).toHaveLength(1);
+    });
+
+    // test that non-device schemaName disables the check
+    test('returns empty for non-device schema', () => {
+        device.params.parent.access_scope = 'st2138:bogus';
+        const result = checkScopes(device, { schemaName: 'param', disableScopeChecks: false });
+        expect(result).toEqual([]);
+        // prove that it would have warned if the schemaName was 'device'
+        const result2 = checkScopes(device, ENABLED_OPTS);
+        expect(result2).toHaveLength(1);
+    });
+
+    // no params, nothing to check, should return empty
+    test('returns empty when device has no params', () => {
+        delete device.params;
+        const result = checkScopes(device, ENABLED_OPTS);
+        expect(result).toEqual([]);
+    });
+
+    // no declared access_scopes: every explicit scope is undeclared
+    test('flags every explicit scope when device declares no access_scopes', () => {
+        delete device.access_scopes;
+        const result = checkScopes(device, ENABLED_OPTS);
+        // params parent (op), child (cfg), leaf (mon) plus command do_thing (op)
+        // all become undeclared; the command argument's scope is still ignored
+        expect(result).toHaveLength(4);
+    });
+
+    // flags a top-level param using an undeclared scope
+    test('flags a top-level param with an undeclared access_scope', () => {
+        device.params.parent.access_scope = 'st2138:adm';
+        const result = checkScopes(device, ENABLED_OPTS);
+        expect(result).toEqual([
+            {
+                message: "Parameter 'parent' has access_scope 'st2138:adm' which is not declared in the device's access_scopes",
+                instancePath: '/params/parent/access_scope',
+                type: ERROR,
+            },
+        ]);
+    });
+
+    // flags a deeply nested param using an undeclared scope
+    test('flags a deeply nested param with an undeclared access_scope', () => {
+        device.params.deep_parent.params.mid.params.leaf.access_scope = 'st2138:adm';
+        const result = checkScopes(device, ENABLED_OPTS);
+        expect(result).toEqual([
+            {
+                message: "Parameter 'leaf' has access_scope 'st2138:adm' which is not declared in the device's access_scopes",
+                instancePath: '/params/deep_parent/params/mid/params/leaf/access_scope',
+                type: ERROR,
+            },
+        ]);
+    });
+
+    // params without an explicit access_scope are never flagged
+    test('does not flag params without an access_scope', () => {
+        delete device.params.parent.access_scope;
+        delete device.params.parent.params.child.access_scope;
+        delete device.params.deep_parent.params.mid.params.leaf.access_scope;
+        const result = checkScopes(device, ENABLED_OPTS);
+        expect(result).toEqual([]);
+    });
+
+    // flags multiple undeclared scopes across the hierarchy
+    test('flags multiple undeclared scopes', () => {
+        device.params.parent.access_scope = 'st2138:adm';
+        device.params.parent.params.child.access_scope = 'st2138:nope';
+        const result = checkScopes(device, ENABLED_OPTS);
+        expect(result).toHaveLength(2);
+        expect(result).toEqual(expect.arrayContaining([
+            {
+                message: "Parameter 'parent' has access_scope 'st2138:adm' which is not declared in the device's access_scopes",
+                instancePath: '/params/parent/access_scope',
+                type: ERROR,
+            },
+            {
+                message: "Parameter 'child' has access_scope 'st2138:nope' which is not declared in the device's access_scopes",
+                instancePath: '/params/parent/params/child/access_scope',
+                type: ERROR,
+            },
+        ]));
+    });
+
+    // R2: flags a top-level command with an undeclared access_scope
+    test('flags a top-level command with an undeclared access_scope', () => {
+        device.commands.do_thing.access_scope = 'st2138:adm';
+        const result = checkScopes(device, ENABLED_OPTS);
+        expect(result).toEqual([
+            {
+                message: "Command 'do_thing' has access_scope 'st2138:adm' which is not declared in the device's access_scopes",
+                instancePath: '/commands/do_thing/access_scope',
+                type: ERROR,
+            },
+        ]);
+    });
+
+    // R2: command arguments (nested params) are ignored, even with a bogus scope
+    test('does not flag command arguments (nested command params)', () => {
+        // the fixture's do_thing.arg already has an undeclared scope; ensure it
+        // is not flagged while the command's own scope is valid
+        const result = checkScopes(device, ENABLED_OPTS);
+        expect(result).toEqual([]);
+    });
+
+    // commands without an explicit access_scope are never flagged
+    test('does not flag commands without an access_scope', () => {
+        delete device.commands.do_thing.access_scope;
+        const result = checkScopes(device, ENABLED_OPTS);
+        expect(result).toEqual([]);
+    });
+
+    // R2: flags multiple top-level commands with undeclared scopes
+    test('flags multiple commands with undeclared scopes', () => {
+        device.commands.do_thing.access_scope = 'st2138:adm';
+        device.commands.other_thing.access_scope = 'st2138:nope';
+        const result = checkScopes(device, ENABLED_OPTS);
+        expect(result).toHaveLength(2);
+        expect(result).toEqual(expect.arrayContaining([
+            {
+                message: "Command 'do_thing' has access_scope 'st2138:adm' which is not declared in the device's access_scopes",
+                instancePath: '/commands/do_thing/access_scope',
+                type: ERROR,
+            },
+            {
+                message: "Command 'other_thing' has access_scope 'st2138:nope' which is not declared in the device's access_scopes",
+                instancePath: '/commands/other_thing/access_scope',
+                type: ERROR,
+            },
+        ]));
+    });
+
+    // R2: commands are still checked when the device has no params at all
+    test('flags an undeclared command scope even when the device has no params', () => {
+        delete device.params;
+        device.commands.do_thing.access_scope = 'st2138:adm';
+        const result = checkScopes(device, ENABLED_OPTS);
+        expect(result).toEqual([
+            {
+                message: "Command 'do_thing' has access_scope 'st2138:adm' which is not declared in the device's access_scopes",
+                instancePath: '/commands/do_thing/access_scope',
+                type: ERROR,
+            },
+        ]);
+    });
+
+    // devices without any commands are handled gracefully (only params checked)
+    test('returns no errors when the device has no commands', () => {
+        delete device.commands;
+        const result = checkScopes(device, ENABLED_OPTS);
+        expect(result).toEqual([]);
+    });
+});

--- a/tools/tests/checks/walker.test.js
+++ b/tools/tests/checks/walker.test.js
@@ -105,15 +105,40 @@ describe('walkParams', () => {
         expect(order).toEqual(['visit:x', 'visit:y', 'finalize']);
     });
 
-    // is a no-op when there is nothing to walk
-    test('does nothing when there is no descriptor, no params, or no visitors', () => {
+    // is a no-op when there is no descriptor or no visitors
+    test('does nothing when there is no descriptor or no visitors', () => {
         const visitor = { visit: jest.fn(), finalize: jest.fn() };
 
         walkParams(null, [visitor], []);
-        walkParams({}, [visitor], []);
+        walkParams(undefined, [visitor], []);
         walkParams({ params: { x: {} } }, [], []);
 
         expect(visitor.visit).not.toHaveBeenCalled();
         expect(visitor.finalize).not.toHaveBeenCalled();
+    });
+
+    // finalize still runs when the descriptor has no params, so params-less
+    // checks (e.g. commands) are not skipped
+    test('runs finalize even when the descriptor has no params', () => {
+        const visit = jest.fn();
+        const finalize = jest.fn((warnings) => warnings.push('finalized'));
+        const warnings = [];
+
+        walkParams({}, [{ visit, finalize }], warnings);
+
+        expect(visit).not.toHaveBeenCalled();
+        expect(finalize).toHaveBeenCalledTimes(1);
+        expect(warnings).toEqual(['finalized']);
+    });
+
+    // an empty params map still triggers finalize without visiting anything
+    test('runs finalize for an empty params map', () => {
+        const visit = jest.fn();
+        const finalize = jest.fn();
+
+        walkParams({ params: {} }, [{ visit, finalize }], []);
+
+        expect(visit).not.toHaveBeenCalled();
+        expect(finalize).toHaveBeenCalledTimes(1);
     });
 });

--- a/tools/tests/checks/walker.test.js
+++ b/tools/tests/checks/walker.test.js
@@ -1,0 +1,119 @@
+/*
+ * Copyright © MMXXVI 2026 by the Society of Motion Picture and Television Engineers
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation and/or
+ *    other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+const { walkParams } = require('../../checks/walker');
+
+describe('walkParams', () => {
+
+    const DEVICE = {
+        params: {
+            a: {
+                type: 'STRUCT',
+                params: {
+                    b: { type: 'STRING' },
+                    c: {
+                        type: 'STRUCT',
+                        params: {
+                            d: { type: 'INT32' },
+                        },
+                    },
+                },
+            },
+            e: { type: 'INT32' },
+        },
+    };
+
+    // capture the context passed for every visited param
+    const collectVisitor = (log) => ({
+        visit(ctx) {
+            log.push({ key: ctx.key, path: ctx.path, depth: ctx.depth });
+        },
+    });
+
+    // visits every param exactly once, depth-first pre-order
+    test('visits every param once in depth-first pre-order', () => {
+        const log = [];
+        walkParams(DEVICE, [collectVisitor(log)], []);
+        expect(log).toEqual([
+            { key: 'a', path: '/params/a', depth: 0 },
+            { key: 'b', path: '/params/a/params/b', depth: 1 },
+            { key: 'c', path: '/params/a/params/c', depth: 1 },
+            { key: 'd', path: '/params/a/params/c/params/d', depth: 2 },
+            { key: 'e', path: '/params/e', depth: 0 },
+        ]);
+    });
+
+    // provides parent and ancestor chain
+    test('provides parent and ancestor context', () => {
+        const seen = {};
+        walkParams(DEVICE, [{
+            visit(ctx) {
+                seen[ctx.key] = {
+                    parentKey: ctx.parent ? ctx.parent.type : null,
+                    ancestors: ctx.ancestors.map((a) => a.key),
+                };
+            },
+        }], []);
+        expect(seen.a).toEqual({ parentKey: null, ancestors: [] });
+        expect(seen.d).toEqual({ parentKey: 'STRUCT', ancestors: ['a', 'c'] });
+        expect(seen.e).toEqual({ parentKey: null, ancestors: [] });
+    });
+
+    // invokes every visitor for each param and shares the warnings list
+    test('invokes all visitors and shares the warnings list', () => {
+        const warnings = [];
+        const first = { visit: (ctx, w) => w.push(`1:${ctx.key}`) };
+        const second = { visit: (ctx, w) => w.push(`2:${ctx.key}`) };
+        walkParams({ params: { x: {} } }, [first, second], warnings);
+        expect(warnings).toEqual(['1:x', '2:x']);
+    });
+
+    // calls finalize once per visitor after the walk completes
+    test('calls finalize after the walk completes', () => {
+        const order = [];
+        const visitor = {
+            visit: (ctx) => order.push(`visit:${ctx.key}`),
+            finalize: () => order.push('finalize'),
+        };
+        walkParams({ params: { x: {}, y: {} } }, [visitor], []);
+        expect(order).toEqual(['visit:x', 'visit:y', 'finalize']);
+    });
+
+    // is a no-op when there is nothing to walk
+    test('does nothing when there is no descriptor, no params, or no visitors', () => {
+        const visitor = { visit: jest.fn(), finalize: jest.fn() };
+
+        walkParams(null, [visitor], []);
+        walkParams({}, [visitor], []);
+        walkParams({ params: { x: {} } }, [], []);
+
+        expect(visitor.visit).not.toHaveBeenCalled();
+        expect(visitor.finalize).not.toHaveBeenCalled();
+    });
+});

--- a/tools/tests/validator.test.js
+++ b/tools/tests/validator.test.js
@@ -306,12 +306,13 @@ describe('Validator', () => {
                 schemaName: 'device',
                 disableMandatoryParams: false,
                 disableNestedValueChecks: false,
+                disableScopeChecks: false,
             }
         );
     });
 
     test('validate passes disable flags through to runChecks', async () => {
-        const validator = new Validator({ disableMandatoryParams: true, disableNestedValueChecks: true });
+        const validator = new Validator({ disableMandatoryParams: true, disableNestedValueChecks: true, disableScopeChecks: true });
         const mockSourceMap = { pointers: {} };
 
         jest.spyOn(Validator, 'loadTestData').mockResolvedValue({
@@ -332,6 +333,7 @@ describe('Validator', () => {
                 schemaName: 'device',
                 disableMandatoryParams: true,
                 disableNestedValueChecks: true,
+                disableScopeChecks: true,
             }
         );
     });

--- a/tools/validator.js
+++ b/tools/validator.js
@@ -16,11 +16,13 @@ class Validator {
      * @param {object} options optional options
      * @param {boolean} options.disableMandatoryParams if true, skip mandatory product parameter checks
      * @param {boolean} options.disableNestedValueChecks if true, skip checks for nested values
+     * @param {boolean} options.disableScopeChecks if true, skip checks for undeclared access scopes
      */
     constructor(options = {}) {
         this.checkOpts = {
             disableMandatoryParams: options.disableMandatoryParams || false,
             disableNestedValueChecks: options.disableNestedValueChecks || false,
+            disableScopeChecks: options.disableScopeChecks || false,
         };
 
         this.ajv = new Ajv({


### PR DESCRIPTION
Add a new check to validate every param/command access_scope against the device's list of scopes.

To support this check, a new check type is added as well. Since walking the param tree is a common task in these checks. Checks can now register a visitor callback that will be called on each param so there can be a single pass over the whole device.