### PR TITLE
Formalize the proto service/message file split

### DIFF
--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -1,0 +1,15 @@
+name: Proto Lint
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  proto-split:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check service/message separation
+        run: bash ./check-proto-split.sh

--- a/check-proto-split.sh
+++ b/check-proto-split.sh
@@ -4,7 +4,7 @@
 #
 # Enforce a clean separation between RPC service definitions and message/enum
 # definitions: any .proto that declares a `service` must not also declare a
-# top-level `message` or `enum`.
+# `message` or `enum`.
 #
 # Why: keeping service definitions in their own file lets language bindings
 # isolate the generated RPC/stub code from the plain data types. Several

--- a/check-proto-split.sh
+++ b/check-proto-split.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# check-proto-split.sh
+#
+# Enforce a clean separation between RPC service definitions and message/enum
+# definitions: any .proto that declares a `service` must not also declare a
+# top-level `message` or `enum`.
+#
+# Why: keeping service definitions in their own file lets language bindings
+# isolate the generated RPC/stub code from the plain data types. Several
+# generators (e.g. Go's protoc-gen-go vs protoc-gen-go-grpc) emit the service
+# stubs -- which pull in a gRPC runtime -- separately from the message types.
+# When a file mixes the two, consumers that only need the messages are forced
+# to link the gRPC runtime as well. Splitting services into dedicated files
+# keeps that boundary intact for every binding.
+#
+# This is a fast, dependency-free lint. It is intentionally strict: a service
+# file must contain no top-level message/enum declarations at all.
+#
+# Usage: ./check-proto-split.sh [PROTO_DIR]   (default: interface/proto)
+
+set -euo pipefail
+
+PROTO_DIR="${1:-interface/proto}"
+
+if [[ ! -d "$PROTO_DIR" ]]; then
+  echo "check-proto-split: proto directory not found: $PROTO_DIR" >&2
+  exit 2
+fi
+
+status=0
+shopt -s nullglob
+protos=("$PROTO_DIR"/*.proto)
+
+if [[ ${#protos[@]} -eq 0 ]]; then
+  echo "check-proto-split: no .proto files found in $PROTO_DIR" >&2
+  exit 2
+fi
+
+for f in "${protos[@]}"; do
+  # Match top-level keyword declarations only (a keyword at the start of a line,
+  # ignoring leading whitespace). Field types reference a message by name and
+  # never repeat the `message`/`enum`/`service` keyword, so this does not
+  # false-positive on usages. Commented-out lines (`// service ...`) are skipped
+  # because the leading `//` prevents the anchor from matching.
+  has_service=$(grep -cE '^[[:space:]]*service[[:space:]]+[A-Za-z_]' "$f" || true)
+  has_type=$(grep -cE '^[[:space:]]*(message|enum)[[:space:]]+[A-Za-z_]' "$f" || true)
+
+  if [[ "$has_service" -gt 0 && "$has_type" -gt 0 ]]; then
+    echo "ERROR: $f declares a service alongside message/enum definitions."
+    echo "       Move the service into its own .proto file; service definitions"
+    echo "       must not share a file with message or enum declarations."
+    status=1
+  fi
+done
+
+if [[ "$status" -eq 0 ]]; then
+  echo "check-proto-split: OK -- no file mixes a service with message/enum declarations."
+fi
+
+exit "$status"

--- a/interface/proto/service.proto
+++ b/interface/proto/service.proto
@@ -42,6 +42,19 @@ import "param.proto";
 import "language.proto";
 import "externalobject.proto";
 
+/*
+ * This file contains only the CatenaService RPC definition; all message and
+ * enum types it references live in the imported .proto files above. Do not add
+ * top-level `message` or `enum` declarations here.
+ *
+ * Keeping service and data-type definitions in separate files lets language
+ * bindings isolate the generated RPC/stub code (which pulls in a gRPC runtime)
+ * from the plain message types, so consumers that only need the messages are
+ * not forced to link the gRPC runtime. Downstream projects rely on this split.
+ *
+ * This invariant is enforced in CI by check-proto-split.sh.
+ */
+
 /* Catena's API */
 service CatenaService {
   rpc DeviceRequest(DeviceRequestPayload) returns (stream DeviceComponent);

--- a/interface/proto/service.proto
+++ b/interface/proto/service.proto
@@ -45,7 +45,7 @@ import "externalobject.proto";
 /*
  * This file contains only the CatenaService RPC definition; all message and
  * enum types it references live in the imported .proto files above. Do not add
- * top-level `message` or `enum` declarations here.
+ * `message` or `enum` declarations here.
  *
  * Keeping service and data-type definitions in separate files lets language
  * bindings isolate the generated RPC/stub code (which pulls in a gRPC runtime)


### PR DESCRIPTION
The `.proto` files follow a convention: service.proto holds the service definition and no messages, and files that define messages/enums do not define a service. This keeps a clean boundary so language bindings can isolate the generated RPC/stub code (which pulls in a gRPC runtime) from the plain data types. Consumers that only need the messages aren't forced to link the gRPC runtime. Downstream projects may already rely on this split.

Until now the rule was informal. This PR enforces it:

- **check-proto-split.sh** — a fast, dependency-free lint that fails if any `.proto` declares a `service` alongside a top-level `message`/`enum`.
- **proto-lint.yml** — runs the check on every push and PR.
- A comment in service.proto documenting the invariant and pointing to the check.

No proto files needed changes — the tree already satisfies the rule.